### PR TITLE
Reinstate armhf which was removed I don't know why

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For now, although the package is fully functional (install, remove, backup, rest
 
 
 
-**Shipped version:** 9.5.1~ynh1
+**Shipped version:** 9.5.1~ynh2
 ## Documentation and resources
 
 * Official app website: <https://zwave-js.github.io/zwave-js-ui/#/>

--- a/README_fr.md
+++ b/README_fr.md
@@ -31,7 +31,7 @@ Pour fonctionner correctement, cette application nécessite d'avoir installé so
 Pour l'instant, bien que le package fonctionne (installation, désinstallation, sauvegarde, restauration...), il n'est pas intégré avec domoticz et mosquitto, les paramétrages doivent être fait manuellement depuis l'application.
 
 
-**Version incluse :** 9.5.1~ynh1
+**Version incluse :** 9.5.1~ynh2
 ## Documentations et ressources
 
 * Site officiel de l’app : <https://zwave-js.github.io/zwave-js-ui/#/>

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Zwave-JS-UI"
 description.en = "Full featured Z-Wave Control Panel and MQTT Gateway integrated with domoticz"
 description.fr = "Panneau de controle Z-Wave et MQTT intégré avec Domoticz"
 
-version = "9.5.1~ynh1"
+version = "9.5.1~ynh2"
 
 maintainers = ["Krakinou"]
 
@@ -19,7 +19,7 @@ fund = "https://liberapay.com/robertsLando/donate"
 
 [integration]
 yunohost = ">= 11.1.18"
-architectures = [ "amd64", "arm64" ]
+architectures = [ "amd64", "armhf", "arm64" ]
 multi_instance = false
 ldap = "not_relevant"
 sso = "not_relevant"
@@ -45,6 +45,8 @@ ram.runtime = "150M"
         [resources.sources.main]
         arm64.url = "https://github.com/zwave-js/zwave-js-ui/releases/download/v9.5.1/zwave-js-ui-v9.5.1-linux-arm64.zip"
         arm64.sha256 = "2faec3a3057d1478fc1a697911a43b3d477d734e71c09241fe43d30543614191"
+        armhf.url = "https://github.com/zwave-js/zwave-js-ui/releases/download/v9.3.2/zwave-js-ui-v9.5.1-linux-armv7.zip"
+        armhf.sha256 = "371c9e8ac6efec543415e79f33738c4636a0a6f28043e76aa258b0e5a0abf8f7"
         amd64.url = "https://github.com/zwave-js/zwave-js-ui/releases/download/v9.5.1/zwave-js-ui-v9.5.1-linux.zip"
         amd64.sha256 = "f45e0f1b2e4bf188bc4ab69324f270b0a28d834f18c04c4be2c59ce1f5a2333b"
         in_subdir = false
@@ -53,6 +55,7 @@ ram.runtime = "150M"
 
         autoupdate.asset.arm64 = ".*-arm64.zip"
         autoupdate.asset.amd64 = ".*-linux.zip"
+        autoupdate.asset.armhf = ".*-armv7.zip"
 
     [resources.system_user]
 


### PR DESCRIPTION
## Problem

- Cannot upgrade to last version on my Raspberry Pi 3 as armhf/armv7 was removed from the package without warning

## Solution

- re-add armhf architecture into manifest.toml

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
