### PR TITLE
Upgrade to v9.30.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For now, although the package is fully functional (install, remove, backup, rest
 
 
 
-**Shipped version:** 9.29.1~ynh1
+**Shipped version:** 9.30.0~ynh1
 ## Documentation and resources
 
 - Official app website: <https://zwave-js.github.io/zwave-js-ui/#/>

--- a/README_es.md
+++ b/README_es.md
@@ -29,7 +29,7 @@ For now, although the package is fully functional (install, remove, backup, rest
 
 
 
-**Versión actual:** 9.29.1~ynh1
+**Versión actual:** 9.30.0~ynh1
 ## Documentaciones y recursos
 
 - Sitio web oficial: <https://zwave-js.github.io/zwave-js-ui/#/>

--- a/README_eu.md
+++ b/README_eu.md
@@ -29,7 +29,7 @@ For now, although the package is fully functional (install, remove, backup, rest
 
 
 
-**Paketatutako bertsioa:** 9.29.1~ynh1
+**Paketatutako bertsioa:** 9.30.0~ynh1
 ## Dokumentazioa eta baliabideak
 
 - Aplikazioaren webgune ofiziala: <https://zwave-js.github.io/zwave-js-ui/#/>

--- a/README_fr.md
+++ b/README_fr.md
@@ -28,7 +28,7 @@ Pour fonctionner correctement, cette application nécessite d'avoir installé so
 Pour l'instant, bien que le package fonctionne (installation, désinstallation, sauvegarde, restauration...), il n'est pas intégré avec domoticz et mosquitto, les paramétrages doivent être fait manuellement depuis l'application.
 
 
-**Version incluse :** 9.29.1~ynh1
+**Version incluse :** 9.30.0~ynh1
 ## Documentations et ressources
 
 - Site officiel de l’app : <https://zwave-js.github.io/zwave-js-ui/#/>

--- a/README_gl.md
+++ b/README_gl.md
@@ -29,7 +29,7 @@ For now, although the package is fully functional (install, remove, backup, rest
 
 
 
-**Versión proporcionada:** 9.29.1~ynh1
+**Versión proporcionada:** 9.30.0~ynh1
 ## Documentación e recursos
 
 - Web oficial da app: <https://zwave-js.github.io/zwave-js-ui/#/>

--- a/README_id.md
+++ b/README_id.md
@@ -29,7 +29,7 @@ For now, although the package is fully functional (install, remove, backup, rest
 
 
 
-**Versi terkirim:** 9.29.1~ynh1
+**Versi terkirim:** 9.30.0~ynh1
 ## Dokumentasi dan sumber daya
 
 - Website aplikasi resmi: <https://zwave-js.github.io/zwave-js-ui/#/>

--- a/README_nl.md
+++ b/README_nl.md
@@ -29,7 +29,7 @@ For now, although the package is fully functional (install, remove, backup, rest
 
 
 
-**Geleverde versie:** 9.29.1~ynh1
+**Geleverde versie:** 9.30.0~ynh1
 ## Documentatie en bronnen
 
 - Officiele website van de app: <https://zwave-js.github.io/zwave-js-ui/#/>

--- a/README_pl.md
+++ b/README_pl.md
@@ -29,7 +29,7 @@ For now, although the package is fully functional (install, remove, backup, rest
 
 
 
-**Dostarczona wersja:** 9.29.1~ynh1
+**Dostarczona wersja:** 9.30.0~ynh1
 ## Dokumentacja i zasoby
 
 - Oficjalna strona aplikacji: <https://zwave-js.github.io/zwave-js-ui/#/>

--- a/README_ru.md
+++ b/README_ru.md
@@ -29,7 +29,7 @@ For now, although the package is fully functional (install, remove, backup, rest
 
 
 
-**Поставляемая версия:** 9.29.1~ynh1
+**Поставляемая версия:** 9.30.0~ynh1
 ## Документация и ресурсы
 
 - Официальный веб-сайт приложения: <https://zwave-js.github.io/zwave-js-ui/#/>

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -29,7 +29,7 @@ For now, although the package is fully functional (install, remove, backup, rest
 
 
 
-**分发版本：** 9.29.1~ynh1
+**分发版本：** 9.30.0~ynh1
 ## 文档与资源
 
 - 官方应用网站： <https://zwave-js.github.io/zwave-js-ui/#/>

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Zwave-JS-UI"
 description.en = "Full featured Z-Wave Control Panel and MQTT Gateway integrated with domoticz"
 description.fr = "Panneau de controle Z-Wave et MQTT intégré avec Domoticz"
 
-version = "9.29.1~ynh1"
+version = "9.30.0~ynh1"
 
 maintainers = ["Krakinou"]
 
@@ -47,12 +47,12 @@ ram.runtime = "150M"
 
 [resources]
         [resources.sources.main]
-        arm64.url = "https://github.com/zwave-js/zwave-js-ui/releases/download/v9.29.1/zwave-js-ui-v9.29.1-linux-arm64.zip"
-        arm64.sha256 = "51e0893243ab4c9a1041ca78a506bc8b52d00656ae5694ddcfa0a0cdffa23ddf"
-        armhf.url = "https://github.com/zwave-js/zwave-js-ui/releases/download/v9.29.1/zwave-js-ui-v9.29.1-linux-armv7.zip"
-        armhf.sha256 = "38dd380fcba372ebee1bc6e9d810b39e0038a40db623d9ab681c6ecddfe2adb9"
-        amd64.url = "https://github.com/zwave-js/zwave-js-ui/releases/download/v9.29.1/zwave-js-ui-v9.29.1-linux.zip"
-        amd64.sha256 = "4214d4feaeef6561a8cbefde76fe1bafe3e4dc105affbc2b5f74b267990711b6"
+        arm64.url = "https://github.com/zwave-js/zwave-js-ui/releases/download/v9.30.0/zwave-js-ui-v9.30.0-linux-arm64.zip"
+        arm64.sha256 = "82a1960c3a7ed7cbd6aba312126ea14764a97e7c91b7e75ceba015ad41736556"
+        armhf.url = "https://github.com/zwave-js/zwave-js-ui/releases/download/v9.30.0/zwave-js-ui-v9.30.0-linux-armv7.zip"
+        armhf.sha256 = "1f6f2410c51ae4e44ad45770a9752a0c6e0c05aa8febd401f499740ad83acc17"
+        amd64.url = "https://github.com/zwave-js/zwave-js-ui/releases/download/v9.30.0/zwave-js-ui-v9.30.0-linux.zip"
+        amd64.sha256 = "70c540c04c8907f0596e8453748c2edafee6fee6d2ba09f668c068b5042bee43"
         in_subdir = false
 
         autoupdate.strategy = "latest_github_release"


### PR DESCRIPTION
Upgrade sources
- `main` v9.30.0: https://github.com/zwave-js/zwave-js-ui/releases/tag/v9.30.0