### PR TITLE
Upgrade to v9.33.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For now, although the package is fully functional (install, remove, backup, rest
 
 
 
-**Shipped version:** 9.33.0~ynh1
+**Shipped version:** 9.33.1~ynh1
 ## Documentation and resources
 
 - Official app website: <https://zwave-js.github.io/zwave-js-ui/#/>

--- a/README_es.md
+++ b/README_es.md
@@ -29,7 +29,7 @@ For now, although the package is fully functional (install, remove, backup, rest
 
 
 
-**Versión actual:** 9.33.0~ynh1
+**Versión actual:** 9.33.1~ynh1
 ## Documentaciones y recursos
 
 - Sitio web oficial: <https://zwave-js.github.io/zwave-js-ui/#/>

--- a/README_eu.md
+++ b/README_eu.md
@@ -29,7 +29,7 @@ For now, although the package is fully functional (install, remove, backup, rest
 
 
 
-**Paketatutako bertsioa:** 9.33.0~ynh1
+**Paketatutako bertsioa:** 9.33.1~ynh1
 ## Dokumentazioa eta baliabideak
 
 - Aplikazioaren webgune ofiziala: <https://zwave-js.github.io/zwave-js-ui/#/>

--- a/README_fr.md
+++ b/README_fr.md
@@ -28,7 +28,7 @@ Pour fonctionner correctement, cette application nécessite d'avoir installé so
 Pour l'instant, bien que le package fonctionne (installation, désinstallation, sauvegarde, restauration...), il n'est pas intégré avec domoticz et mosquitto, les paramétrages doivent être fait manuellement depuis l'application.
 
 
-**Version incluse :** 9.33.0~ynh1
+**Version incluse :** 9.33.1~ynh1
 ## Documentations et ressources
 
 - Site officiel de l’app : <https://zwave-js.github.io/zwave-js-ui/#/>

--- a/README_gl.md
+++ b/README_gl.md
@@ -29,7 +29,7 @@ For now, although the package is fully functional (install, remove, backup, rest
 
 
 
-**Versión proporcionada:** 9.33.0~ynh1
+**Versión proporcionada:** 9.33.1~ynh1
 ## Documentación e recursos
 
 - Web oficial da app: <https://zwave-js.github.io/zwave-js-ui/#/>

--- a/README_id.md
+++ b/README_id.md
@@ -29,7 +29,7 @@ For now, although the package is fully functional (install, remove, backup, rest
 
 
 
-**Versi terkirim:** 9.33.0~ynh1
+**Versi terkirim:** 9.33.1~ynh1
 ## Dokumentasi dan sumber daya
 
 - Website aplikasi resmi: <https://zwave-js.github.io/zwave-js-ui/#/>

--- a/README_nl.md
+++ b/README_nl.md
@@ -29,7 +29,7 @@ For now, although the package is fully functional (install, remove, backup, rest
 
 
 
-**Geleverde versie:** 9.33.0~ynh1
+**Geleverde versie:** 9.33.1~ynh1
 ## Documentatie en bronnen
 
 - Officiele website van de app: <https://zwave-js.github.io/zwave-js-ui/#/>

--- a/README_pl.md
+++ b/README_pl.md
@@ -29,7 +29,7 @@ For now, although the package is fully functional (install, remove, backup, rest
 
 
 
-**Dostarczona wersja:** 9.33.0~ynh1
+**Dostarczona wersja:** 9.33.1~ynh1
 ## Dokumentacja i zasoby
 
 - Oficjalna strona aplikacji: <https://zwave-js.github.io/zwave-js-ui/#/>

--- a/README_ru.md
+++ b/README_ru.md
@@ -29,7 +29,7 @@ For now, although the package is fully functional (install, remove, backup, rest
 
 
 
-**Поставляемая версия:** 9.33.0~ynh1
+**Поставляемая версия:** 9.33.1~ynh1
 ## Документация и ресурсы
 
 - Официальный веб-сайт приложения: <https://zwave-js.github.io/zwave-js-ui/#/>

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -29,7 +29,7 @@ For now, although the package is fully functional (install, remove, backup, rest
 
 
 
-**分发版本：** 9.33.0~ynh1
+**分发版本：** 9.33.1~ynh1
 ## 文档与资源
 
 - 官方应用网站： <https://zwave-js.github.io/zwave-js-ui/#/>

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Zwave-JS-UI"
 description.en = "Full featured Z-Wave Control Panel and MQTT Gateway integrated with domoticz"
 description.fr = "Panneau de controle Z-Wave et MQTT intégré avec Domoticz"
 
-version = "9.33.0~ynh1"
+version = "9.33.1~ynh1"
 
 maintainers = ["Krakinou"]
 
@@ -50,12 +50,12 @@ ram.runtime = "150M"
 [resources]
 
     [resources.sources.main]
-    arm64.url = "https://github.com/zwave-js/zwave-js-ui/releases/download/v9.33.0/zwave-js-ui-v9.33.0-linux-arm64.zip"
-    arm64.sha256 = "37dc7308d5da7ec50380ba0a817438e85af0761094ef3221be8ad829253adcf9"
-    armhf.url = "https://github.com/zwave-js/zwave-js-ui/releases/download/v9.33.0/zwave-js-ui-v9.33.0-linux-armv7.zip"
-    armhf.sha256 = "2eb1b0dcc50975cf82755da176ed12a50a490f11a0cf980f389158c9f065a74d"
-    amd64.url = "https://github.com/zwave-js/zwave-js-ui/releases/download/v9.33.0/zwave-js-ui-v9.33.0-linux.zip"
-    amd64.sha256 = "5b997c6199d79d5bf6b498d075f8cf29576240581b92fe1858b430be69a4460a"
+    arm64.url = "https://github.com/zwave-js/zwave-js-ui/releases/download/v9.33.1/zwave-js-ui-v9.33.1-linux-arm64.zip"
+    arm64.sha256 = "e05e22336ed94e5960c949631ec06b8fa63485b9388c32c8dee5035b49098ca7"
+    armhf.url = "https://github.com/zwave-js/zwave-js-ui/releases/download/v9.33.1/zwave-js-ui-v9.33.1-linux-armv7.zip"
+    armhf.sha256 = "6ace24c02378cb3cb0c30cfbc67f3b1815f7d1baeba067355e6414ed9da04ca9"
+    amd64.url = "https://github.com/zwave-js/zwave-js-ui/releases/download/v9.33.1/zwave-js-ui-v9.33.1-linux.zip"
+    amd64.sha256 = "0f40390125a34d152703fb1f481a0d275731ba4d3f81cfabd4831495544b91ba"
     in_subdir = false
 
     autoupdate.strategy = "latest_github_release"


### PR DESCRIPTION
Upgrade sources
- `main` v9.33.1: https://github.com/zwave-js/zwave-js-ui/releases/tag/v9.33.1

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
