### PR TITLE
Remove ram.runtime setting

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -30,7 +30,6 @@ ldap = "not_relevant"
 sso = "not_relevant"
 
 disk = "1024M"
-ram.runtime = "150M"
 
 [install]
     [install.domain]


### PR DESCRIPTION
ram.build and ram.runtime require to be together
